### PR TITLE
Community apps no longer cause 404 at TLD

### DIFF
--- a/tld.sh
+++ b/tld.sh
@@ -112,7 +112,7 @@ if [[ "$old" != "$new" && "$old" != "NOT-SET" ]]; then
 
   if [[ "$tldtype" == "standard" ]]; then
     if [ -e "/opt/coreapps/apps/$old.yml" ]; then ansible-playbook /opt/coreapps/apps/$old.yml; fi
-    if [ -e "/opt/coreapps/communityapps/$old.yml" ]; then ansible-playbook /opt/coreapps/apps/$old.yml; fi
+    if [ -e "/opt/coreapps/communityapps/$old.yml" ]; then ansible-playbook /opt/communityapps/apps/$old.yml; fi
   elif [[ "$tldtype" == "wordpress" ]]; then
     echo "$old" > /tmp/wp_id
     ansible-playbook /opt/pgpress/wordpress.yml
@@ -122,7 +122,7 @@ if [[ "$old" != "$new" && "$old" != "NOT-SET" ]]; then
 fi
 
 if [ -e "/opt/coreapps/apps/$new.yml" ]; then ansible-playbook /opt/coreapps/apps/$new.yml; fi
-if [ -e "/opt/coreapps/communityapps/$new.yml" ]; then ansible-playbook /opt/coreapps/apps/$new.yml; fi
+if [ -e "/opt/coreapps/communityapps/$new.yml" ]; then ansible-playbook /opt/communityapps/apps/$new.yml; fi
 echo "standard" > /var/plexguide/tld.type
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Comm apps were giving a 404 error because of bad directory setting.
Without fix, manually running "ansible-playbook /opt/communityapps/apps/xyz.yml" fixes the issue